### PR TITLE
fix: 动态页解析失败(B 站接口 following/live_id/epid/up 主列表 mid 等字段类型变更)

### DIFF
--- a/lib/http/dynamics.dart
+++ b/lib/http/dynamics.dart
@@ -76,7 +76,11 @@ class DynamicsHttp {
       },
     );
     if (res.data['code'] == 0) {
-      return Success(FollowUpModel.fromJson(res.data['data']));
+      try {
+        return Success(FollowUpModel.fromJson(res.data['data']));
+      } catch (err) {
+        return Error(err.toString());
+      }
     } else {
       return Error(res.data['message']);
     }
@@ -92,7 +96,11 @@ class DynamicsHttp {
       },
     );
     if (res.data['code'] == 0) {
-      return Success(DynUpList.fromJson(res.data['data']));
+      try {
+        return Success(DynUpList.fromJson(res.data['data']));
+      } catch (err) {
+        return Error(err.toString());
+      }
     } else {
       return Error(res.data['message']);
     }

--- a/lib/models/dynamics/result.dart
+++ b/lib/models/dynamics/result.dart
@@ -393,7 +393,7 @@ class ModuleAuthorModel extends Avatar {
     if (json['official'] != null) {
       officialVerify ??= BaseOfficialVerify.fromJson(json['official']); // opus
     }
-    following = json['following'];
+    following = SafeType.toBool(json['following']);
     jumpUrl = json['jump_url'];
     label = json['label'];
     pubAction = json['pub_action'];
@@ -1459,7 +1459,7 @@ class DynamicLiveModel {
       uid = livePlayInfo['uid'];
       parentAreaName = livePlayInfo['parent_area_name'];
       roomId = livePlayInfo['room_id'];
-      liveId = livePlayInfo['live_id'];
+      liveId = SafeType.toStr(livePlayInfo['live_id']);
       liveStatus = livePlayInfo['live_status'];
       cover = livePlayInfo['cover'];
       online = livePlayInfo['online'];

--- a/lib/models/dynamics/result.dart
+++ b/lib/models/dynamics/result.dart
@@ -1249,8 +1249,8 @@ class DynamicArchiveModel {
     stat = json['stat'] != null ? Stat.fromJson(json['stat']) : null;
     title = json['title'];
     type = json['type'];
-    epid = json['epid'];
-    seasonId = json['season_id'];
+    epid = SafeType.toInt(json['epid']);
+    seasonId = SafeType.toInt(json['season_id']);
   }
 }
 

--- a/lib/models/dynamics/up.dart
+++ b/lib/models/dynamics/up.dart
@@ -1,3 +1,5 @@
+import 'package:PiliPro/utils/safe_type.dart';
+
 class FollowUpModel {
   FollowUpModel({
     this.liveUsers,
@@ -64,11 +66,11 @@ class LiveUserItem extends UpItem {
   String? title;
 
   LiveUserItem.fromJson(Map<String, dynamic> json)
-    : super(mid: json['mid'] ?? 0) {
+    : super(mid: SafeType.toInt(json['mid']) ?? 0) {
     face = json['face'];
     isReserveRecall = json['is_reserve_recall'];
     jumpUrl = json['jump_url'];
-    roomId = json['room_id'];
+    roomId = SafeType.toInt(json['room_id']);
     title = json['title'];
     uname = json['uname'];
   }
@@ -90,7 +92,7 @@ class UpItem {
   UpItem.fromJson(Map<String, dynamic> json) {
     face = json['face'];
     hasUpdate = json['has_update'];
-    mid = json['mid'] ?? 0;
+    mid = SafeType.toInt(json['mid']) ?? 0;
     uname = json['uname'];
   }
 }

--- a/test/dynamic_following_parse_test.dart
+++ b/test/dynamic_following_parse_test.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:PiliPro/common/widgets/pendant_avatar.dart';
+import 'package:PiliPro/models/dynamics/result.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// 回归测试: B 站 feed/all 接口字段类型变更 (2026-06 观测到)。
+/// - module_author.following: bool -> int (0/1)
+/// - live_rcmd.content (JSON 字符串) 内 live_play_info.live_id: str -> int64
+/// 异常会被请求层 catch 成字符串展示在 UI 上, 第一个错误会掩盖第二个,
+/// 因此两处必须同时修复。夹具为手工构造的合成数据, 不含真实用户信息。
+void main() {
+  test('DynamicsDataModel parses items with int following / int live_id', () {
+    // 先给惰性静态字段赋值, 避免测试环境里初始化 Hive
+    DynamicsDataModel.banWordForDyn = RegExp('', caseSensitive: false);
+    DynamicsDataModel.enableFilter = false;
+    DynamicsDataModel.antiGoodsDyn = false;
+    PendantAvatar.showDynDecorate = true;
+
+    final raw = File(
+      'test/fixtures/dynamic_feed_type_change_sample.json',
+    ).readAsStringSync();
+    final json = jsonDecode(raw) as Map<String, dynamic>;
+
+    final data = DynamicsDataModel.fromJson(json);
+
+    expect(data.hasMore, true);
+    expect(data.items, isNotNull);
+    expect(data.items!.length, 2);
+
+    // following: 1 -> true, 0 -> false
+    expect(data.items![0].modules.moduleAuthor!.following, true);
+    expect(data.items![1].modules.moduleAuthor!.following, false);
+
+    // live_id: int64 -> String
+    final live = data.items![1].modules.moduleDynamic!.major!.liveRcmd!;
+    expect(live.liveId, '707000000000000001');
+    expect(live.roomId, 1234567);
+    expect(live.liveStatus, 1);
+    expect(live.title, '测试直播标题');
+  });
+}

--- a/test/dynamic_following_parse_test.dart
+++ b/test/dynamic_following_parse_test.dart
@@ -8,10 +8,11 @@ import 'package:flutter_test/flutter_test.dart';
 /// 回归测试: B 站 feed/all 接口字段类型变更 (2026-06 观测到)。
 /// - module_author.following: bool -> int (0/1)
 /// - live_rcmd.content (JSON 字符串) 内 live_play_info.live_id: str -> int64
-/// 异常会被请求层 catch 成字符串展示在 UI 上, 第一个错误会掩盖第二个,
-/// 因此两处必须同时修复。夹具为手工构造的合成数据, 不含真实用户信息。
+/// - 番剧(PGC)动态 major.pgc.epid / season_id: int -> str
+/// 异常会被请求层 catch 成字符串展示在 UI 上, 第一个错误会掩盖后面的,
+/// 因此这些点必须同时修复。夹具为手工构造的合成数据, 不含真实用户信息。
 void main() {
-  test('DynamicsDataModel parses items with int following / int live_id', () {
+  test('DynamicsDataModel parses items with changed field types', () {
     // 先给惰性静态字段赋值, 避免测试环境里初始化 Hive
     DynamicsDataModel.banWordForDyn = RegExp('', caseSensitive: false);
     DynamicsDataModel.enableFilter = false;
@@ -27,7 +28,7 @@ void main() {
 
     expect(data.hasMore, true);
     expect(data.items, isNotNull);
-    expect(data.items!.length, 2);
+    expect(data.items!.length, 3);
 
     // following: 1 -> true, 0 -> false
     expect(data.items![0].modules.moduleAuthor!.following, true);
@@ -39,5 +40,11 @@ void main() {
     expect(live.roomId, 1234567);
     expect(live.liveStatus, 1);
     expect(live.title, '测试直播标题');
+
+    // 番剧(PGC): epid / season_id 字符串 -> int
+    final pgc = data.items![2].modules.moduleDynamic!.major!.pgc!;
+    expect(pgc.epid, 3915346);
+    expect(pgc.seasonId, 216918);
+    expect(pgc.title, '合成测试番剧标题');
   });
 }

--- a/test/fixtures/dynamic_feed_type_change_sample.json
+++ b/test/fixtures/dynamic_feed_type_change_sample.json
@@ -1,7 +1,7 @@
 {
   "has_more": true,
   "offset": "fixture_offset",
-  "total": 2,
+  "total": 3,
   "items": [
     {
       "id_str": "100000000000000001",
@@ -42,6 +42,48 @@
             "live_rcmd": {
               "reserve_type": "RESERVE_TYPE_NONE",
               "content": "{\"type\":1,\"live_play_info\":{\"uid\":10010,\"parent_area_name\":\"测试分区\",\"room_id\":1234567,\"live_id\":707000000000000001,\"live_status\":1,\"cover\":\"https://example.com/cover.jpg\",\"online\":42,\"area_name\":\"测试子分区\",\"title\":\"测试直播标题\",\"live_start_time\":1781000000,\"watched_show\":{\"switch\":true,\"num\":12,\"text_small\":\"12\",\"text_large\":\"12人看过\",\"icon\":\"\",\"icon_location\":\"\"}}}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "id_str": "100000000000000003",
+      "type": "DYNAMIC_TYPE_PGC_UNION",
+      "visible": true,
+      "modules": {
+        "module_author": {
+          "mid": 20020,
+          "name": "合成测试番剧出品",
+          "face": "https://example.com/face3.png",
+          "following": 1,
+          "pub_time": "3小时前",
+          "pub_ts": 1781000002,
+          "type": "AUTHOR_TYPE_PGC"
+        },
+        "module_dynamic": {
+          "major": {
+            "type": "MAJOR_TYPE_PGC",
+            "pgc": {
+              "type": 2,
+              "sub_type": "0",
+              "season_id": "216918",
+              "epid": "3915346",
+              "title": "合成测试番剧标题",
+              "cover": "https://example.com/pgc-cover.jpg",
+              "badge": {
+                "text": "综艺",
+                "bg_color": "#FB7299",
+                "color": "#FFFFFF"
+              },
+              "jump_url": "https://www.bilibili.com/bangumi/play/ep3915346",
+              "stat": {
+                "danmaku": "146",
+                "play": "314万",
+                "vt": ""
+              },
+              "enable_vt": 0,
+              "stat_hidden": 0
             }
           }
         }

--- a/test/fixtures/dynamic_feed_type_change_sample.json
+++ b/test/fixtures/dynamic_feed_type_change_sample.json
@@ -1,0 +1,51 @@
+{
+  "has_more": true,
+  "offset": "fixture_offset",
+  "total": 2,
+  "items": [
+    {
+      "id_str": "100000000000000001",
+      "type": "DYNAMIC_TYPE_AV",
+      "visible": true,
+      "modules": {
+        "module_author": {
+          "mid": 10086,
+          "name": "合成测试UP主",
+          "face": "https://example.com/face.png",
+          "following": 1,
+          "jump_url": "//space.bilibili.com/10086/dynamic",
+          "label": "",
+          "pub_action": "投稿了视频",
+          "pub_time": "1小时前",
+          "pub_ts": 1781000000,
+          "type": "AUTHOR_TYPE_NORMAL"
+        }
+      }
+    },
+    {
+      "id_str": "100000000000000002",
+      "type": "DYNAMIC_TYPE_LIVE_RCMD",
+      "visible": true,
+      "modules": {
+        "module_author": {
+          "mid": 10010,
+          "name": "合成测试主播",
+          "face": "https://example.com/face2.png",
+          "following": 0,
+          "pub_time": "直播中",
+          "pub_ts": 1781000001,
+          "type": "AUTHOR_TYPE_NORMAL"
+        },
+        "module_dynamic": {
+          "major": {
+            "type": "MAJOR_TYPE_LIVE_RCMD",
+            "live_rcmd": {
+              "reserve_type": "RESERVE_TYPE_NONE",
+              "content": "{\"type\":1,\"live_play_info\":{\"uid\":10010,\"parent_area_name\":\"测试分区\",\"room_id\":1234567,\"live_id\":707000000000000001,\"live_status\":1,\"cover\":\"https://example.com/cover.jpg\",\"online\":42,\"area_name\":\"测试子分区\",\"title\":\"测试直播标题\",\"live_start_time\":1781000000,\"watched_show\":{\"switch\":true,\"num\":12,\"text_small\":\"12\",\"text_large\":\"12人看过\",\"icon\":\"\",\"icon_location\":\"\"}}}"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/fixtures/portal_up_list_type_change_sample.json
+++ b/test/fixtures/portal_up_list_type_change_sample.json
@@ -1,0 +1,46 @@
+{
+  "live_users": {
+    "count": 2,
+    "group": "default",
+    "items": [
+      {
+        "face": "https://i0.hdslb.com/bfs/face/synthetic_live_1.jpg",
+        "is_reserve_recall": false,
+        "jump_url": "https://live.bilibili.com/21000001",
+        "mid": "10000001",
+        "room_id": "21000001",
+        "title": "合成测试直播间标题一",
+        "uname": "合成测试主播一"
+      },
+      {
+        "face": "https://i0.hdslb.com/bfs/face/synthetic_live_2.jpg",
+        "is_reserve_recall": true,
+        "jump_url": "https://live.bilibili.com/21000002",
+        "mid": "10000002",
+        "room_id": "21000002",
+        "title": "合成测试直播间标题二",
+        "uname": "合成测试主播二"
+      }
+    ]
+  },
+  "up_list": {
+    "has_more": true,
+    "offset": "5_1718000000",
+    "items": [
+      {
+        "face": "https://i0.hdslb.com/bfs/face/synthetic_up_1.jpg",
+        "has_update": true,
+        "is_reserve_recall": false,
+        "mid": 20000001,
+        "uname": "合成测试UP一"
+      },
+      {
+        "face": "https://i0.hdslb.com/bfs/face/synthetic_up_2.jpg",
+        "has_update": false,
+        "is_reserve_recall": false,
+        "mid": "20000002",
+        "uname": "合成测试UP二"
+      }
+    ]
+  }
+}

--- a/test/portal_up_list_parse_test.dart
+++ b/test/portal_up_list_parse_test.dart
@@ -1,0 +1,38 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:PiliPro/models/dynamics/up.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// 回归测试: B 站 web-dynamic/v1/portal 接口字段类型变更 (2026-06 观测到)。
+/// - live_users.items[].mid: int -> str
+/// - live_users.items[].room_id: int -> str
+/// 解析炸掉后 followUp() 没有 catch, 动态页左侧 up 主列表整体空白;
+/// 且只在有关注的 UP 开播 (live_users.items 非空) 时触发, 表现为间歇性。
+/// 夹具为手工构造的合成数据, 不含真实用户信息。
+void main() {
+  test('FollowUpModel parses portal response with string mid/room_id', () {
+    final raw = File(
+      'test/fixtures/portal_up_list_type_change_sample.json',
+    ).readAsStringSync();
+    final json = jsonDecode(raw) as Map<String, dynamic>;
+
+    final data = FollowUpModel.fromJson(json);
+
+    // live_users: mid/room_id 字符串 -> int
+    final liveItems = data.liveUsers!.items!;
+    expect(liveItems.length, 2);
+    expect(liveItems[0].mid, 10000001);
+    expect(liveItems[0].roomId, 21000001);
+    expect(liveItems[1].mid, 10000002);
+    expect(liveItems[1].roomId, 21000002);
+    expect(liveItems[1].isReserveRecall, true);
+
+    // up_list: 当前 mid 仍是 int, 但需兼容未来转 str
+    expect(data.upList.length, 2);
+    expect(data.upList[0].mid, 20000001);
+    expect(data.upList[1].mid, 20000002);
+    expect(data.hasMore, true);
+    expect(data.offset, '5_1718000000');
+  });
+}


### PR DESCRIPTION
Fixes #31

## 问题

B 站 `feed/all` 接口改了两个字段的类型,动态页「全部」标签加载即报
`type 'int' is not a subtype of type 'bool?'`。由于请求层 catch 异常后只把
字符串交给 UI,第一个错误会掩盖第二个——实际有两处需要修,详见关联 issue。

2026-06-12 追加:`portal` 接口(动态页左侧 up 主列表)的 `live_users` 字段也发生了
同族类型变更,导致**只要有关注的 UP 在直播,up 主列表整体空白**(间歇性,见 issue 第 4 节)。

## 改动

`lib/models/dynamics/result.dart` 与 `lib/models/dynamics/up.dart`,均改用项目现成的 `SafeType`:

| 字段 | 接口变化 | 修复 |
|---|---|---|
| `module_author.following` | bool → int (0/1) | `SafeType.toBool(json['following'])` |
| `live_play_info.live_id`(`live_rcmd.content` 内) | str → int64 | `SafeType.toStr(livePlayInfo['live_id'])` |
| `major.pgc.epid` / `major.pgc.season_id`(番剧动态) | int → str | `SafeType.toInt(...)` |
| `live_users.items[].mid` / `room_id`(portal 接口,up 主列表) | int → str | `SafeType.toInt(...)` |
| `followUp()` / `dynUpList()` 请求层(`lib/http/dynamics.dart`) | —(防御) | 补 try/catch,解析异常显示为错误而非无限 Loading |

`SafeType.toBool`/`toStr`/`toInt` 均对原类型透传、对变化后的类型做安全转换,旧格式保持兼容。

## 测试

- 新增 `test/dynamic_following_parse_test.dart` + 合成数据夹具
  `test/fixtures/dynamic_feed_type_change_sample.json`(无真实用户数据),
  覆盖 feed/all 三处类型变更,跑真实解析链 `DynamicsDataModel.fromJson`。
  修复前分别在两处抛 TypeError,修复后通过。
- 新增 `test/portal_up_list_parse_test.dart` + 合成夹具
  `test/fixtures/portal_up_list_type_change_sample.json`,覆盖 portal 接口
  `mid`/`room_id` 的类型变更。修复前抛
  `type 'String' is not a subtype of type 'int'`(栈指向 `LiveUserItem.fromJson`),修复后通过。
- 实机验证:动态页「全部」标签正常加载,滚动多屏(视频/图文/直播等类型)无错误,
  logcat 无 Flutter 异常;在 5 个关注 UP 正在直播(原必炸条件)的情况下,
  up 主列表与 Live 分组正常显示。
