### PR TITLE
fix: 应用内小窗状态下进入系统 PiP 显示首页而非视频

### DIFF
--- a/lib/services/live_pip_floating_widget.dart
+++ b/lib/services/live_pip_floating_widget.dart
@@ -1,5 +1,6 @@
 // lib/services/live_pip_floating_widget.dart
 import 'dart:async';
+import 'package:floating/floating.dart';
 import 'package:flutter/material.dart';
 import 'package:PiliPro/services/live_pip_controller.dart';
 import 'package:media_kit_video/media_kit_video.dart';
@@ -60,6 +61,23 @@ class _LivePipFloatingWidgetState extends State<LivePipFloatingWidget> {
 
     if (liveData == null) {
       return const SizedBox.shrink();
+    }
+
+    // 系统 PiP(桌面小窗)下铺满渲染直播画面,同 PipFloatingWidget
+    if (Floating().isPipMode) {
+      return Positioned.fill(
+        child: ColoredBox(
+          color: Colors.black,
+          child: AbsorbPointer(
+            child: liveData.plPlayerController.videoController != null
+                ? Video(
+                    controller: liveData.plPlayerController.videoController!,
+                    controls: NoVideoControls,
+                  )
+                : const SizedBox.shrink(),
+          ),
+        ),
+      );
     }
     // 把 pip 小窗的放在右下角,如果没有缓存的话
     if (controller.position.value == null) {

--- a/lib/services/pip_floating_widget.dart
+++ b/lib/services/pip_floating_widget.dart
@@ -1,5 +1,6 @@
 // lib/services/pip_floating_widget.dart
 import 'dart:async';
+import 'package:floating/floating.dart';
 import 'package:flutter/material.dart';
 import 'package:PiliPro/services/pip_controller.dart';
 
@@ -55,6 +56,18 @@ class _PipFloatingWidgetState extends State<PipFloatingWidget> {
   Widget build(BuildContext context) {
     final screenSize = MediaQuery.of(context).size;
     final controller = PipController.to;
+
+    // 系统 PiP(桌面小窗)下整个 activity 被缩成小窗,此时应铺满渲染视频,
+    // 而不是显示带角落浮窗的整页内容(进出 PiP 会改变窗口尺寸触发重建)
+    if (Floating().isPipMode) {
+      final videoPlayer = controller.getVideoPlayer(true);
+      return Positioned.fill(
+        child: ColoredBox(
+          color: Colors.black,
+          child: AbsorbPointer(child: videoPlayer ?? const SizedBox.shrink()),
+        ),
+      );
+    }
 
     if (controller.position.value == null) {
       _position = Offset(


### PR DESCRIPTION
Fixes #36

## 问题

视频缩成应用内小窗后按 Home，系统 PiP（桌面小窗）显示的是整个首页 + 角落浮窗，而不是视频。根因见关联 issue：视频页 pop 后没人响应 PiP 模式，而自动进入 PiP 的注册仍然生效。

## 改动

仅两个文件，净增 31 行：

- `lib/services/pip_floating_widget.dart`、`lib/services/live_pip_floating_widget.dart`：build 中检测 `Floating().isPipMode` 为 true 时，改为 `Positioned.fill` 全屏渲染播放器（黑底、屏蔽手势），与 `pages/video/view.dart` 中视频页的 PiP 处理保持同构。
- 无需额外监听：进出 PiP 必然改变窗口尺寸，这两个依赖 `MediaQuery` 的组件会自动重建。
- 判断放在角落位置计算**之前**，避免 PiP 的小窗尺寸覆写浮窗位置缓存。

## 测试

实机验证（Android 16 / SDK 36）：
- 视频 → 应用内小窗 → Home：PiP 显示视频画面（见 issue 描述）
- 从桌面返回 app：恢复为角落小窗继续播放，位置不漂移
- 从视频页直接 Home 进 PiP 的原有路径不受影响
- `dart analyze` 两文件无告警

🤖 Generated with [Claude Code](https://claude.com/claude-code)
